### PR TITLE
Make DID method configurable instead of hardcoding "hedera"

### DIFF
--- a/hiero_did_sdk_python/did/hedera_did.py
+++ b/hiero_did_sdk_python/did/hedera_did.py
@@ -11,6 +11,7 @@ from ..utils.keys import get_key_type
 from .did_document import DidDocument
 from .did_document_operation import DidDocumentOperation
 from .did_error import DidException
+from .did_syntax import HEDERA_DID_METHOD
 from .hcs import HcsDidMessageEnvelope
 from .hcs.events import HcsDidEvent
 from .hcs.events.document import HcsDidDeleteEvent
@@ -40,12 +41,20 @@ class HederaDid:
         client: Hedera Client
         identifier: DID identifier (for existing DIDs)
         private_key_der: DID Owner (controller) private key encoded in DER format. Can be empty for read-only access
+        did_method: The DID method to use. Defaults to HEDERA_DID_METHOD
     """
 
-    def __init__(self, client: Client, identifier: str | None = None, private_key_der: str | None = None):
+    def __init__(
+        self,
+        client: Client,
+        identifier: str | None = None,
+        private_key_der: str | None = None,
+        did_method: str = HEDERA_DID_METHOD,
+    ):
         if not identifier and not private_key_der:
             raise DidException("'identifier' and 'private_key_der' cannot both be empty")
 
+        self.did_method = did_method
         self._client = client
         self._hcs_topic_service = HcsTopicService(client)
 
@@ -59,6 +68,7 @@ class HederaDid:
             parsed_identifier = parse_identifier(self.identifier)
             self.network = parsed_identifier.network
             self.topic_id = parsed_identifier.topic_id
+            self.did_method = parsed_identifier.method
         else:
             self.topic_id = None
 
@@ -85,6 +95,7 @@ class HederaDid:
                 self.network,
                 multibase_encode(bytes(self._private_key.public_key().to_bytes_raw()), "base58btc"),
                 self.topic_id,
+                self.did_method,
             )
 
         hcs_event = HcsDidUpdateDidOwnerEvent(

--- a/hiero_did_sdk_python/did/utils.py
+++ b/hiero_did_sdk_python/did/utils.py
@@ -67,6 +67,7 @@ class ParsedIdentifier:
     network: str
     topic_id: str
     public_key_base58: str
+    method: str = HEDERA_DID_METHOD
 
 
 def parse_identifier(identifier: str) -> ParsedIdentifier:
@@ -83,10 +84,6 @@ def parse_identifier(identifier: str) -> ParsedIdentifier:
         raise DidException("DID string is invalid: invalid prefix.", DidErrorCode.INVALID_DID_STRING)
 
     method_name = did_parts.pop(0)
-    if method_name != HEDERA_DID_METHOD:
-        raise DidException(
-            "DID string is invalid: invalid method name: " + method_name, DidErrorCode.INVALID_DID_STRING
-        )
 
     try:
         network_name = did_parts.pop(0)
@@ -107,7 +104,7 @@ def parse_identifier(identifier: str) -> ParsedIdentifier:
         if topic_id and not TOPIC_ID_REGEX.match(topic_id):
             raise DidException("DID string is invalid. Topic ID doesn't match pattern", DidErrorCode.INVALID_DID_STRING)
 
-        return ParsedIdentifier(network_name, topic_id, public_key_base58)
+        return ParsedIdentifier(network_name, topic_id, public_key_base58, method_name)
     except Exception as error:
         if isinstance(error, DidException):
             raise error
@@ -115,8 +112,8 @@ def parse_identifier(identifier: str) -> ParsedIdentifier:
         raise DidException("DID string is invalid. " + str(error), DidErrorCode.INVALID_DID_STRING) from error
 
 
-def build_identifier(network: str, public_key: str, topic_id: str):
-    network_segment = f"{HEDERA_DID_METHOD}{DID_METHOD_SEPARATOR}{network}"
+def build_identifier(network: str, public_key: str, topic_id: str, method: str = HEDERA_DID_METHOD):
+    network_segment = f"{method}{DID_METHOD_SEPARATOR}{network}"
 
     return (
         DID_PREFIX

--- a/tests/unit/did/test_utils.py
+++ b/tests/unit/did/test_utils.py
@@ -15,11 +15,6 @@ class TestUtils:
             ("invalidDid1", DidException, "DID string is invalid: topic ID is missing"),
             ("did:invalid", DidException, "DID string is invalid: topic ID is missing"),
             (
-                "did:invalidMethod:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.24352",
-                DidException,
-                "DID string is invalid: invalid method name: invalidMethod",
-            ),
-            (
                 "did:hedera:invalidNetwork:8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.24352",
                 DidException,
                 "DID string is invalid. Invalid Hedera network.",
@@ -55,11 +50,6 @@ class TestUtils:
                 DidException,
                 "DID string is invalid. ID holds incorrect format.",
             ),
-            (
-                "did:notHedera:testnet:z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak_0.0.1",
-                DidException,
-                "DID string is invalid. invalid method name: notHedera",
-            ),
         ),
     )
     def test_parse_invalid_identifier_throws_error(self, identifier, expected_exception, expected_message):
@@ -77,6 +67,12 @@ class TestUtils:
                 "2JjAddF8hvcU9gFQJrx7uZFAcSzXbu4YvadiFoJk6aKw3LPwDnE9UsoQjS8sEJgi5xyzNHk5PF2Gh",
                 "0.0.5047476",
             ),
+            (
+                "hiero",
+                "testnet",
+                "2JjAddF8hvcU9gFQJrx7uZFAcSzXbu4YvadiFoJk6aKw3LPwDnE9UsoQjS8sEJgi5xyzNHk5PF2Gh",
+                "0.0.5047476",
+            ),
         ),
     )
     def test_parse_valid_identifier(self, network, subnetwork, encoded_string, topic_id):
@@ -86,6 +82,7 @@ class TestUtils:
         parsed_identifier = parse_identifier(identifier)
 
         assert isinstance(parsed_identifier, ParsedIdentifier)
+        assert parsed_identifier.method == network
         assert parsed_identifier.network == subnetwork
         assert parsed_identifier.topic_id == topic_id
         assert parsed_identifier.public_key_base58 == encoded_string
@@ -100,14 +97,18 @@ class TestUtils:
         assert isinstance(parse_identifier(identifier), ParsedIdentifier)
 
     @pytest.mark.parametrize(
-        ("subnetwork", "public_key", "topic_id"),
+        ("subnetwork", "public_key", "topic_id", "method"),
         (
-            ("testnet", "z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak", "0.0.1"),
-            ("mainnet", "7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm", "0.0.12345"),
+            ("testnet", "z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak", "0.0.1", "hedera"),
+            ("mainnet", "7Prd74ry1Uct87nZqL3ny7aR7Cg46JamVbJgk8azVgUm", "0.0.12345", "hedera"),
+            ("testnet", "z6Mk8LjUL78kFVnWV9rFnNCTE5bZdRmjm2obqJwS892jVLak", "0.0.1", "hiero"),
         ),
     )
-    def test_build_identifier(self, subnetwork, public_key, topic_id):
-        identifier = build_identifier(subnetwork, public_key, topic_id)
+    def test_build_identifier(self, subnetwork, public_key, topic_id, method):
+        if method == "hedera":
+            identifier = build_identifier(subnetwork, public_key, topic_id)
+        else:
+            identifier = build_identifier(subnetwork, public_key, topic_id, method)
 
         assert isinstance(identifier, str)
-        assert identifier == f"did:hedera:{subnetwork}:{public_key}_{topic_id}"
+        assert identifier == f"did:{method}:{subnetwork}:{public_key}_{topic_id}"


### PR DESCRIPTION
Fixes #6

This change removes the hardcoded "hedera" method from DID construction and makes it configurable.

Earlier, all DIDs were always created using did:hedera:..., which made the code tightly coupled to a single network. With this update, the DID method can now be set dynamically, while still keeping "hedera" as the default so existing behavior continues to work as before.

What was changed
Updated DID construction logic to accept a configurable method
Kept "hedera" as the default value for backward compatibility
Improved parsing so it reads the method from the DID instead of assuming it
Updated tests to cover both default and custom methods (for example did:hiero:...)

This makes it easier to use the SDK with other Hiero-based networks without breaking current usage.